### PR TITLE
Possible fix for #24. Loading of gInboxTweaks changed. Now not loading from Assets folder.

### DIFF
--- a/gInbox/WebViewController.swift
+++ b/gInbox/WebViewController.swift
@@ -93,7 +93,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             windowScriptObject.setValue(self, forKey: "gInbox")
             windowScriptObject.evaluateWebScript("console = { log: function(msg) { gInbox.consoleLog(msg); } }")
             
-            let path = NSBundle.mainBundle().pathForResource("gInboxTweaks", ofType: "js", inDirectory: "Assets")
+            let path = NSBundle.mainBundle().pathForResource("gInboxTweaks", ofType: "js")
             let jsString = String(contentsOfFile: path!, encoding: NSUTF8StringEncoding, error: nil)
             let script = document.createElement("script")
             let jsText = document.createTextNode(jsString)


### PR DESCRIPTION
#24 Loading of gInboxTweaks changed. Now not loading from Assets folder. And it works fine on my machine - 10.10.2 Yosemite.
