### PR TITLE
Set default user agent string to Safari

### DIFF
--- a/gInbox/Defaults.plist
+++ b/gInbox/Defaults.plist
@@ -7,6 +7,6 @@
 	<key>hangoutsMode</key>
 	<integer>0</integer>
 	<key>userAgentString</key>
-	<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36</string>
+	<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18</string>
 </dict>
 </plist>


### PR DESCRIPTION
As Inbox now doesn't require a Chrome user agent anymore, you could use Safari as the default user agent.